### PR TITLE
Bring build.yml To New Standard Version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,15 +25,22 @@ jobs:
     - name: Versions
       run: |
         python3 --version
-    - uses: actions/checkout@v1
+    - name: Checkout Current Repo
+      uses: actions/checkout@v1
       with:
         submodules: true
-    - name: Install deps
+    - name: Checkout tools repo
+      uses: actions/checkout@v2
+      with:
+        repository: adafruit/actions-ci-circuitpython-libs
+        path: actions-ci
+    - name: Install dependencies
+      # (e.g. - apt-get: gettext, etc; pip: circuitpython-build-tools, requirements.txt; etc.)
       run: |
-        sudo apt-get install -y gettext
-        pip install -r requirements.txt
-        pip install circuitpython-build-tools Sphinx sphinx-rtd-theme
-        pip install --force-reinstall "pylint<3"
+        source actions-ci/install.sh
+    - name: Pip install pylint, black, & Sphinx
+      run: |
+        pip install --force-reinstall "pylint<3" black==19.10b0 Sphinx sphinx-rtd-theme
     - name: Library version
       run: git describe --dirty --always --tags
     - name: PyLint


### PR DESCRIPTION
Addresses skipped/failed patch from: https://github.com/adafruit/actions-ci-circuitpython-libs/issues/2#issuecomment-595315282

_This keeps the last pylint version at `<3`_